### PR TITLE
ActiveMQ-core has brought a lot of dependency, but these are no less, so needs to be replaced

### DIFF
--- a/async/message-listener-adapter/pom.xml
+++ b/async/message-listener-adapter/pom.xml
@@ -21,10 +21,20 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-core</artifactId>
-    </dependency>
+	<dependency>
+		<groupId>org.apache.activemq</groupId>
+		<artifactId>activemq-client</artifactId>
+		<version>5.10.0</version>
+	</dependency>
+	<dependency>
+		<groupId>org.jboss.spec.javax.jms</groupId>
+		<artifactId>jboss-jms-api_1.1_spec</artifactId>
+		<version>1.0.1.Final</version>
+	</dependency>     
+<!--     <dependency> -->
+<!--       <groupId>org.apache.activemq</groupId> -->
+<!--       <artifactId>activemq-core</artifactId> -->
+<!--     </dependency> -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/async/message-listener/pom.xml
+++ b/async/message-listener/pom.xml
@@ -21,10 +21,20 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-core</artifactId>
-    </dependency>
+	<dependency>
+		<groupId>org.apache.activemq</groupId>
+		<artifactId>activemq-client</artifactId>
+		<version>5.10.0</version>
+	</dependency>
+	<dependency>
+		<groupId>org.jboss.spec.javax.jms</groupId>
+		<artifactId>jboss-jms-api_1.1_spec</artifactId>
+		<version>1.0.1.Final</version>
+	</dependency>    
+<!--     <dependency> -->
+<!--       <groupId>org.apache.activemq</groupId> -->
+<!--       <artifactId>activemq-core</artifactId> -->
+<!--     </dependency> -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/sync/jms-template/pom.xml
+++ b/sync/jms-template/pom.xml
@@ -21,10 +21,20 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.apache.activemq</groupId>
-      <artifactId>activemq-core</artifactId>
-    </dependency>
+	<dependency>
+		<groupId>org.jboss.spec.javax.jms</groupId>
+		<artifactId>jboss-jms-api_1.1_spec</artifactId>
+		<version>1.0.1.Final</version>
+	</dependency>
+	<dependency>
+		<groupId>org.apache.activemq</groupId>
+		<artifactId>activemq-client</artifactId>
+		<version>5.10.0</version>
+	</dependency>    
+<!--     <dependency> -->
+<!--       <groupId>org.apache.activemq</groupId> -->
+<!--       <artifactId>activemq-core</artifactId> -->
+<!--     </dependency> -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
I use ActiveMQ-client and jboss-jms-api_1.1_spec .

[INFO] +- org.apache.activemq:activemq-core:jar:5.6.0:compile
[INFO] |  +- org.apache.geronimo.specs:geronimo-jms_1.1_spec:jar:1.1.1:compile
[INFO] |  +- org.apache.activemq:kahadb:jar:5.6.0:compile
[INFO] |  +- org.apache.activemq.protobuf:activemq-protobuf:jar:1.1:compile
[INFO] |  +- org.fusesource.fuse-extra:fusemq-leveldb:jar:1.1:compile
[INFO] |  |  +- org.fusesource.hawtbuf:hawtbuf-proto:jar:1.9:compile
[INFO] |  |  +- org.fusesource.hawtdispatch:hawtdispatch-scala:jar:1.9:compile
[INFO] |  |  |  - org.fusesource.hawtdispatch:hawtdispatch:jar:1.9:compile
[INFO] |  |  +- org.iq80.leveldb:leveldb:jar:0.2:compile
[INFO] |  |  |  +- org.iq80.leveldb:leveldb-api:jar:0.2:compile
[INFO] |  |  |  +- com.google.inject:guice:jar:3.0:compile
[INFO] |  |  |  |  - javax.inject:javax.inject:jar:1:compile
[INFO] |  |  |  +- com.google.inject.extensions:guice-multibindings:jar:3.0:compile
[INFO] |  |  |  - com.google.guava:guava:jar:10.0.1:compile
[INFO] |  |  |     - com.google.code.findbugs:jsr305:jar:1.3.9:compile
[INFO] |  |  +- org.fusesource.leveldbjni:leveldbjni-osx:jar:1.2:compile
[INFO] |  |  |  - org.fusesource.leveldbjni:leveldbjni:jar:1.2:compile
[INFO] |  |  |     - org.fusesource.hawtjni:hawtjni-runtime:jar:1.5:compile
[INFO] |  |  +- org.fusesource.leveldbjni:leveldbjni-linux32:jar:1.2:compile
[INFO] |  |  +- org.fusesource.leveldbjni:leveldbjni-linux64:jar:1.2:compile
[INFO] |  |  +- org.xerial.snappy:snappy-java:jar:1.0.3:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-core:jar:1.0.0:compile
[INFO] |  |  |  +- commons-configuration:commons-configuration:jar:1.6:compile
[INFO] |  |  |  |  +- commons-collections:commons-collections:jar:3.2.1:compile
[INFO] |  |  |  |  +- commons-lang:commons-lang:jar:2.4:compile
[INFO] |  |  |  |  +- commons-digester:commons-digester:jar:1.8:compile
[INFO] |  |  |  |  |  - commons-beanutils:commons-beanutils:jar:1.7.0:compile
[INFO] |  |  |  |  - commons-beanutils:commons-beanutils-core:jar:1.8.0:compile
[INFO] |  |  |  +- org.mortbay.jetty:jetty:jar:6.1.26:compile
[INFO] |  |  |  |  - org.mortbay.jetty:servlet-api:jar:2.5-20081211:compile
[INFO] |  |  |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
[INFO] |  |  |  +- org.mortbay.jetty:jsp-api-2.1:jar:6.1.14:compile
[INFO] |  |  |  |  - org.mortbay.jetty:servlet-api-2.5:jar:6.1.14:compile
[INFO] |  |  |  - org.mortbay.jetty:jsp-2.1:jar:6.1.14:compile
[INFO] |  |  |     - ant:ant:jar:1.6.5:compile
[INFO] |  |  - org.scala-lang:scala-library:jar:2.9.1:compile
[INFO] |  +- org.fusesource.mqtt-client:mqtt-client:jar:1.0:compile
[INFO] |  |  +- org.fusesource.hawtdispatch:hawtdispatch-transport:jar:1.9:compile
[INFO] |  |  - org.fusesource.hawtbuf:hawtbuf:jar:1.9:compile
[INFO] |  +- org.osgi:org.osgi.core:jar:4.1.0:compile
[INFO] |  +- org.apache.geronimo.specs:geronimo-j2ee-management_1.1_spec:jar:1.0.1:compile
[INFO] |  +- org.springframework:spring-context:jar:3.0.6.RELEASE:compile
[INFO] |  |  - org.springframework:spring-expression:jar:3.0.6.RELEASE:compile
[INFO] |  +- commons-net:commons-net:jar:2.2:compile
[INFO] |  - org.jasypt:jasypt:jar:1.8:compile
Signed-off-by: Jacarri Chan 772929989@qq.com
